### PR TITLE
Rename core functions to denote sync or async

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,48 @@
+# Clojure CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-clojure/ for more details
+#
+version: 2.1
+
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/clojure:lein-2.9.5
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+
+    working_directory: ~/repo
+
+    environment:
+      LEIN_ROOT: "true"
+      # Customize the JVM maximum heap limit
+      JVM_OPTS: -Xmx3200m
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "project.clj" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run: lein deps
+
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v1-dependencies-{{ checksum "project.clj" }}
+
+      # run tests!
+      - run: lein test
+
+workflows:
+  build:
+    jobs:
+      - build

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/uwcpdx/stepwise/tree/master.svg?style=svg)](https://circleci.com/gh/uwcpdx/stepwise/tree/master) 
+[![CircleCI](https://circleci.com/gh/Motiva-AI/stepwise/tree/master.svg?style=svg)](https://circleci.com/gh/Motiva-AI/stepwise/tree/master)
 
 # Stepwise
 
@@ -23,7 +23,7 @@ Here's how to make a trivial state machine that just adds two inputs together. T
 
 For your dependencies:
 
-`[uwcpdx/stepwise "0.5.8"]`
+`[motiva/stepwise "0.6.0"]`
 
 At the REPL:
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ At the REPL:
 (stepwise/start-workers {:activity/add (fn [{:keys [x y]}] (+ x y))})
 => ...
 
-(stepwise/run-execution :adder {:input {:x 1 :y 1}})
+(stepwise/start-execution!! :adder {:input {:x 1 :y 1}})
 =>
 {:input             {:x 1 :y 1}
  :output            2
@@ -57,18 +57,18 @@ At the REPL:
 
 ## Development Workflow
 
-Stepwise enables a rapidly cycling development workflow for Step Functions. State machine definition updates are eventually consistent, so new state machines need to be created on each cycle during development. Also, activity task polls are long and cannot be interrupted, demanding registration of new activities (or a JVM restart) to prevent stealing by stale bytecode. Stepwise provides a single function, `stepwise.reloaded/run-execution`, that uses fresh state machine and activity task registrations to run a state machine execution wherein code changes are immediately reflected.
+Stepwise enables a rapidly cycling development workflow for Step Functions. State machine definition updates are eventually consistent, so new state machines need to be created on each cycle during development. Also, activity task polls are long and cannot be interrupted, demanding registration of new activities (or a JVM restart) to prevent stealing by stale bytecode. Stepwise provides a single function, `stepwise.reloaded/start-execution!!`, that uses fresh state machine and activity task registrations to run a state machine execution wherein code changes are immediately reflected.
 
 Example:
 
 ```clojure
-(stepwise.reloaded/run-execution :adder
-                                 {:start-at :add
-                                  :states   {:add {:type     :task
-                                                   :resource :activity/add
-                                                   :end      true}}}
-                                 {:activity/add (fn [{:keys [x y]}] (+ x y))}
-                                 {:x 41 :y 1})
+(stepwise.reloaded/start-execution!! :adder
+                                     {:start-at :add
+                                      :states   {:add {:type     :task
+                                                       :resource :activity/add
+                                                       :end      true}}}
+                                     {:activity/add (fn [{:keys [x y]}] (+ x y))}
+                                     {:x 41 :y 1})
 =>
 {:output 42,
  :state-machine-arn "arn:aws:states:us-west-2:256212633204:stateMachine:adder-1522697821734",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ At the REPL:
                                                  :end      true}}})
 => "arn:aws:states:us-west-2:123456789012:stateMachine:adder"
 
-(stepwise/start-workers {:activity/add (fn [{:keys [x y]}] (+ x y))})
+(stepwise/start-workers! {:activity/add (fn [{:keys [x y]}] (+ x y))})
 => ...
 
 (stepwise/start-execution!! :adder {:input {:x 1 :y 1}})

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,0 @@
-deployment:
-  clojars:
-    branch: master
-    commands:
-      - lein test
-      - lein deploy clojars
-

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject uwcpdx/stepwise "0.5.9-SNAPSHOT"
+(defproject motiva/stepwise "0.6.0-SNAPSHOT"
   :profiles {:dev {:dependencies [[org.clojure/tools.namespace "1.1.0"]
                                   [org.clojure/clojure "1.10.3"]
                                   [org.clojure/spec.alpha "0.2.194"]
@@ -12,10 +12,12 @@
                    :injections   [(require 'pjstadig.humane-test-output)
                                   (pjstadig.humane-test-output/activate!)]
                    :main         stepwise.dev-repl}}
+
   :deploy-repositories {"clojars" {:url           "https://clojars.org/repo"
-                                   :username      :env/CLOJARS_USERNAME
-                                   :password      :env/CLOJARS_PASSWORD
+                                   :username      "motiva-ai"
+                                   :password      :env
                                    :sign-releases false}}
+
   :dependencies [[uwcpdx/bean-dip "0.7.6"]
                  [org.clojure/tools.logging "1.1.0"]
                  [org.clojure/data.json "2.2.2"]

--- a/project.clj
+++ b/project.clj
@@ -1,14 +1,14 @@
 (defproject uwcpdx/stepwise "0.5.9-SNAPSHOT"
-  :profiles {:dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
-                                  [org.clojure/clojure "1.9.0"]
-                                  [org.clojure/spec.alpha "0.1.143"]
-                                  [pjstadig/humane-test-output "0.8.1"]
-                                  [org.slf4j/slf4j-simple "1.7.25"]
-                                  [com.gfredericks/test.chuck "0.2.7"]
+  :profiles {:dev {:dependencies [[org.clojure/tools.namespace "1.1.0"]
+                                  [org.clojure/clojure "1.10.3"]
+                                  [org.clojure/spec.alpha "0.2.194"]
+                                  [pjstadig/humane-test-output "0.11.0"]
+                                  [org.slf4j/slf4j-simple "1.7.30"]
+                                  [com.gfredericks/test.chuck "0.2.10"]
                                   [org.clojure/clojure "1.9.0"]
                                   ; TODO pending jdk 9 compat https://github.com/pallet/alembic/pull/16
                                   #_[alembic "0.3.2"]
-                                  [org.clojure/test.check "0.9.0"]]
+                                  [org.clojure/test.check "1.1.0"]]
                    :injections   [(require 'pjstadig.humane-test-output)
                                   (pjstadig.humane-test-output/activate!)]
                    :main         stepwise.dev-repl}}
@@ -16,11 +16,11 @@
                                    :username      :env/CLOJARS_USERNAME
                                    :password      :env/CLOJARS_PASSWORD
                                    :sign-releases false}}
-  :dependencies [[uwcpdx/bean-dip "0.7.5"]
-                 [org.clojure/tools.logging "0.4.0"]
-                 [org.clojure/data.json "0.2.6"]
-                 [org.clojure/core.async "0.4.474"]
-                 [com.amazonaws/aws-java-sdk-iam "1.11.230"]
-                 [com.amazonaws/aws-java-sdk-sts "1.11.230"]
-                 [com.amazonaws/aws-java-sdk-stepfunctions "1.11.230"]])
+  :dependencies [[uwcpdx/bean-dip "0.7.6"]
+                 [org.clojure/tools.logging "1.1.0"]
+                 [org.clojure/data.json "2.2.2"]
+                 [org.clojure/core.async "1.3.618"]
+                 [com.amazonaws/aws-java-sdk-iam "1.11.1007"]
+                 [com.amazonaws/aws-java-sdk-sts "1.11.1007"]
+                 [com.amazonaws/aws-java-sdk-stepfunctions "1.11.1007"]])
 

--- a/src/stepwise/core.clj
+++ b/src/stepwise/core.clj
@@ -53,7 +53,7 @@
                               ; TODO nil execution-name here causes step functions to gen one?
                               :name  execution-name}))))
 
-(defn await-execution [execution-arn]
+(defn- await-execution [execution-arn]
   ; TODO occasionally not long enough for execution to even be visible yet -- catch
   (Thread/sleep 500)
   (loop [execution (client/describe-execution execution-arn)]

--- a/src/stepwise/core.clj
+++ b/src/stepwise/core.clj
@@ -87,16 +87,16 @@
                        (activities/compile-all))
                    task-concurrency))))
 
-(defn wait-all-exit! [{:keys [exit-chans]}]
+(defn wait-all-exit!! [{:keys [exit-chans]}]
   (->> (async/merge exit-chans)
        (async/into #{})
        (async/<!!)))
 
 (defn shutdown-workers [workers]
   (async/>!! (:terminate-chan workers) :shutdown)
-  (wait-all-exit! workers))
+  (wait-all-exit!! workers))
 
 (defn kill-workers [workers]
   (async/>!! (:terminate-chan workers) :kill)
-  (wait-all-exit! workers))
+  (wait-all-exit!! workers))
 

--- a/src/stepwise/core.clj
+++ b/src/stepwise/core.clj
@@ -72,9 +72,9 @@
   ([state-machine-name {:keys [input execution-name] :as opts}]
    (await-execution (start-execution! state-machine-name opts))))
 
-(defn start-workers
+(defn start-workers!
   ([task-handlers]
-   (start-workers task-handlers nil))
+   (start-workers! task-handlers nil))
   ([task-handlers {:keys [task-concurrency]}]
    (let [activity->arn (into {}
                              (map (fn [activity-name]

--- a/src/stepwise/core.clj
+++ b/src/stepwise/core.clj
@@ -39,9 +39,9 @@
        (activities/resolve-resources arns/resource-arn->kw)
        (denamespace-keys)))
 
-(defn start-execution
+(defn start-execution!
   ([state-machine-name]
-   (start-execution state-machine-name nil))
+   (start-execution! state-machine-name nil))
   ([state-machine-name {:keys [input execution-name]}]
    ; TODO always include these(?)
    (let [input (if execution-name
@@ -66,11 +66,11 @@
           (recur (client/describe-execution execution-arn)))
       (denamespace-keys execution))))
 
-(defn run-execution
+(defn start-execution!!
   ([state-machine-name]
-   (run-execution state-machine-name nil))
+   (start-execution!! state-machine-name nil))
   ([state-machine-name {:keys [input execution-name] :as opts}]
-   (await-execution (start-execution state-machine-name opts))))
+   (await-execution (start-execution! state-machine-name opts))))
 
 (defn start-workers
   ([task-handlers]

--- a/src/stepwise/reloaded.clj
+++ b/src/stepwise/reloaded.clj
@@ -22,7 +22,7 @@
                                        (name activity-name))]))
         activity-names))
 
-(defn run-execution [machine-name definition task-handlers input]
+(defn start-execution!! [machine-name definition task-handlers input]
   (let [snapshot-name      (machine-name->snapshot machine-name)
         activity-names     (activities/get-names definition)
         activity->snapshot (activity-name->snapshot snapshot-name activity-names)
@@ -31,9 +31,9 @@
         snapshot-arn       (core/ensure-state-machine snapshot-name definition)
         workers            (core/start-workers (sets/rename-keys task-handlers
                                                                  activity->snapshot))
-        result             (core/run-execution snapshot-name
-                                               {:input          input
-                                                :execution-name (str (UUID/randomUUID))})]
+        result             (core/start-execution!! snapshot-name
+                                                   {:input          input
+                                                    :execution-name (str (UUID/randomUUID))})]
     (core/kill-workers workers)
     (doseq [[_ snapshot-name] activity->snapshot]
       (client/delete-activity (arns/get-activity-arn snapshot-name)))

--- a/src/stepwise/reloaded.clj
+++ b/src/stepwise/reloaded.clj
@@ -29,8 +29,8 @@
         definition         (activities/resolve-kw-resources activity->snapshot
                                                             definition)
         snapshot-arn       (core/ensure-state-machine snapshot-name definition)
-        workers            (core/start-workers (sets/rename-keys task-handlers
-                                                                 activity->snapshot))
+        workers            (core/start-workers! (sets/rename-keys task-handlers
+                                                                  activity->snapshot))
         result             (core/start-execution!! snapshot-name
                                                    {:input          input
                                                     :execution-name (str (UUID/randomUUID))})]

--- a/test/stepwise/dev_repl.clj
+++ b/test/stepwise/dev_repl.clj
@@ -91,7 +91,7 @@
           rand-ns     (str (rand-int 20))
           machine-id  (keyword "dev-repl" rand-ns)
           activity-kw (keyword "dev-repl" rand-ns)
-          workers     (stepwise/start-workers namespace {activity-kw (fn [{:keys [a b]}] (throw (ex-info "hi" {:error :blamo})))})]
+          workers     (stepwise/start-workers! namespace {activity-kw (fn [{:keys [a b]}] (throw (ex-info "hi" {:error :blamo})))})]
       (stepwise/ensure-state-machine namespace
                                      machine-id
                                      {:start-at :foo

--- a/test/stepwise/dev_repl.clj
+++ b/test/stepwise/dev_repl.clj
@@ -39,13 +39,13 @@
       (mdl/map->StateMachine)))
 
 (defn sandbox []
-  (reloaded/run-execution :adder
-                          {:start-at :add
-                           :states   {:add {:type     :task
-                                            :resource :activity/add
-                                            :end      true}}}
-                          {:activity/add (fn [{:keys [x y]}] (+ x y))}
-                          {:x 41 :y 1})
+  (reloaded/start-execution!! :adder
+                              {:start-at :add
+                               :states   {:add {:type     :task
+                                                :resource :activity/add
+                                                :end      true}}}
+                              {:activity/add (fn [{:keys [x y]}] (+ x y))}
+                              {:x 41 :y 1})
 
   #_(s/explain-data ::sgr/state-machine
                     {:start-at :my-choice
@@ -100,10 +100,10 @@
                                                        :timeout-seconds 3
                                                        :end             true}}})
 
-      (stepwise/run-execution namespace
-                              machine-id
-                              {:input {:a 1
-                                       :b 2}})
+      (stepwise/start-execution!! namespace
+                                  machine-id
+                                  {:input {:a 1
+                                           :b 2}})
       (stepwise/shutdown-workers workers)
       )
 
@@ -115,16 +115,16 @@
   ;                                             :timeout-seconds 3
   ;                                             :end             true}}})
 
-  #_(reloaded/run-execution "ncgl-dev-dacc"
-                            :test-machine-v2
-                            {:start-at :do-the-sum
-                             :states   {:do-the-sum {:type            :task
-                                                     :resource        :sum
-                                                     :timeout-seconds 180
-                                                     :end             true}}}
-                            {:sum (fn [{:keys [a b]}] (+ a b))}
-                            {:a 1
-                             :b 2})
+  #_(reloaded/start-execution!! "ncgl-dev-dacc"
+                                :test-machine-v2
+                                {:start-at :do-the-sum
+                                 :states   {:do-the-sum {:type            :task
+                                                         :resource        :sum
+                                                         :timeout-seconds 180
+                                                         :end             true}}}
+                                {:sum (fn [{:keys [a b]}] (+ a b))}
+                                {:a 1
+                                 :b 2})
   #_(sgr/get-non-model-keys {:foo [{:bar :bam}]
                              :bim {:boom          :bap
                                    ::mdl/resource "hi"}})

--- a/test/stepwise/dev_repl.clj
+++ b/test/stepwise/dev_repl.clj
@@ -2,7 +2,7 @@
   (:require [stepwise.model :as mdl]
             [stepwise.sugar :as sgr]
             [stepwise.reloaded :as reloaded]
-            [stepwise.core :as core]
+            [stepwise.core :as stepwise]
             [clojure.spec.gen.alpha :as sgen]
             [clojure.repl :refer :all]
             [stepwise.specs.sugar :as sgrs]
@@ -81,33 +81,33 @@
   ;(client/start-execution "arn:aws:states:us-west-2:256212633204:stateMachine:test-machine" {:input {:hi "foo"}})
   ;#spy/p (client/get-execution-history "arn:aws:states:us-west-2:256212633204:execution:test-machine:ebba36d3-3a4c-4d51-a97b-d6409043a998")
   ;(client/list-state-machines)
-  #_(core/boot-workers "ncgl-dev-dacc"
-                       {:hello-world-v3 {:start-at :foo
-                                         :states   {:foo {:type     :task
-                                                          :resource ::add
-                                                          :end      true}}}}
-                       {::add (fn [])})
+  #_(stepwise/boot-workers "ncgl-dev-dacc"
+                           {:hello-world-v3 {:start-at :foo
+                                             :states   {:foo {:type     :task
+                                                              :resource ::add
+                                                              :end      true}}}}
+                           {::add (fn [])})
   #_(let [namespace   "ncgl-dev-dacc"
           rand-ns     (str (rand-int 20))
           machine-id  (keyword "dev-repl" rand-ns)
           activity-kw (keyword "dev-repl" rand-ns)
-          workers     (core/start-workers namespace {activity-kw (fn [{:keys [a b]}] (throw (ex-info "hi" {:error :blamo})))})]
-      (core/ensure-state-machine namespace
-                                 machine-id
-                                 {:start-at :foo
-                                  :states   {:foo {:type            :task
-                                                   :resource        activity-kw
-                                                   :timeout-seconds 3
-                                                   :end             true}}})
+          workers     (stepwise/start-workers namespace {activity-kw (fn [{:keys [a b]}] (throw (ex-info "hi" {:error :blamo})))})]
+      (stepwise/ensure-state-machine namespace
+                                     machine-id
+                                     {:start-at :foo
+                                      :states   {:foo {:type            :task
+                                                       :resource        activity-kw
+                                                       :timeout-seconds 3
+                                                       :end             true}}})
 
-      (core/run-execution namespace
-                          machine-id
-                          {:input {:a 1
-                                   :b 2}})
-      (core/shutdown-workers workers)
+      (stepwise/run-execution namespace
+                              machine-id
+                              {:input {:a 1
+                                       :b 2}})
+      (stepwise/shutdown-workers workers)
       )
 
-  ;(core/create-state-machine "ncgl-dev-dacc"
+  ;(stepwise/create-state-machine "ncgl-dev-dacc"
   ;                           ::machine
   ;                           {:start-at :foo
   ;                            :states   {:foo {:type            :task


### PR DESCRIPTION
using core.async naming convention, suffix `!!` and `!`